### PR TITLE
feat: Add video_url parameter to addSoundToList function

### DIFF
--- a/components/SymbolCard.js
+++ b/components/SymbolCard.js
@@ -47,7 +47,7 @@ export default function SymbolCard({ objectSound, onUpdate }) {
 
   const handleAddButton = () => {
     setIsAdded(true);
-    addSoundToList({ user_id: user.id, symbol_id: objectSound.id })
+    addSoundToList({ user_id: user.id, symbol_id: objectSound.id, video_url: objectSound.video_url || '' })
       .then(() => {
         onUpdate();
       })


### PR DESCRIPTION
This commit modifies the addSoundToList function in the SymbolCard component to include a video_url parameter. If the objectSound has a video_url property, it will be passed along with the user_id and symbol_id when calling the addSoundToList function. This enhancement ensures that the video URL is included when adding a sound to the list.

Note: This commit message follows the convention used in the recent repository commits.